### PR TITLE
Update nexus and run script to become domain agnostic 

### DIFF
--- a/modulefiles/tasks/hera/run_nexus.local
+++ b/modulefiles/tasks/hera/run_nexus.local
@@ -1,0 +1,10 @@
+#%Module
+## Module file for run_nexus task.
+#############################################################
+
+## Load NCO
+module load nco/4.9.3
+
+## Load ufswm python environment
+module load hpc-miniconda3/4.6.14
+module load ufswm/1.0.0


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
This change adds in the capability to run larger domains than just over CONUS.  It uses the latest dev branch of NEXUS (hash: 5a48785).  This is needed as minor updates to NEXUS and upgrades the submodule to the latest dev branch of HEMCO from the authoritative repository.  Changes listed below:

- Updated anthropogenic emissions are a blending of NEI v2016, CEDS 2019, Edgar, HTAP, OMI-HTAP SO2
- Updated biogenic emissions: This uses a base year (2019) of MERRA2 data to run the MEGAN v2.1 extension within HEMCO.  This is needed for larger domains because BEIS is not applicable outside of CONUS.
- Updates exregional_run_nexus.sh to link instead of copy NEXUS input files reducing run directory filesize
- Updated NEI linker python library to be able to add version of NEI emissions.
- Updated NEI Emissions to ensure mass conservation (some discrepancies were found from the original dataset) 
- A new helper utility to create better NEXUS output was created and added to the workflow.  This allows easier diagnostics of emission outputs/inputs for the model.
- An NCO helper utility to combine the MEGAN biogenic emissions and anthropogenic emissions into single variables was created as a work around until MEGAN becomes an inline model process. 
- new run_nexus module file to load NCO and the ufswm conda environment from hpc-stack


## TESTS CONDUCTED: 
I completed a short test on HERA.  Here is the config.sh file used 

```bash 
MACHINE="hera"
ACCOUNT="naqfc"
EXPT_BASEDIR="/scratch1/NCEPDEV/stmp2/$LOGNAME/expt_dirs"
EXPT_SUBDIR="uwm_aqm_hrrr25"

PRINT_ESMF="FALSE"

RUN_ENVIR="community"
PREEXISTING_DIR_METHOD="rename"

USE_CRON_TO_RELAUNCH="TRUE"
CRON_RELAUNCH_INTVL_MNTS="3"

CPL_AQM="TRUE"

PREDEF_GRID_NAME="GSD_HRRR_25km"
HALO_BLEND="0"

CCPP_PHYS_SUITE="FV3_GFS_v16"
FCST_LEN_HRS="6"
LBC_SPEC_INTVL_HRS="6"

DATE_FIRST_CYCL="20190805"
DATE_LAST_CYCL="20190805"
CYCL_HRS=( "12" )

RESTART_INTERVAL="6"

WTIME_RUN_FCST="00:30:00"

RUN_TASK_ADD_AQM_LBCS="TRUE"
RUN_TASK_RUN_NEXUS="TRUE"
RUN_TASK_RUN_POST="TRUE"

RUN_ADD_AQM_CHEM_LBCS="TRUE"
RUN_ADD_AQM_GEFS_LBCS="TRUE"
AQM_GEFS_CYC="00"

DIAG_TABLE_TMPL_FN="diag_table_aqm"
FIELD_TABLE_TMPL_FN="field_table_aqm"

#USER_AQM_RC_DIR="/scratch2/NCEPDEV/naqfc/RRFS_CMAQ/sample_config"
AQM_RC_TMPL_FN="aqm.rc"

AQM_CONFIG_DIR="/scratch2/NCEPDEV/naqfc/RRFS_CMAQ/aqm/epa/data"
AQM_BIO_DIR="/scratch2/NCEPDEV/naqfc/RRFS_CMAQ/aqm/bio"
AQM_BIO_FILE="BEIS_SARC401.ncf"
AQM_FIRE_DIR="/scratch2/NCEPDEV/naqfc/RRFS_CMAQ/emissions/GSCE/GBBEPx.in.C401/Reprocessed"
AQM_FIRE_FILE="GBBEPx_C401GRID.emissions_v003"
AQM_FIRE_FILE_SUFFIX=".nc"
AQM_RC_FIRE_FREQUENCY="static"
AQM_LBCS_DIR="/scratch2/NCEPDEV/naqfc/RRFS_CMAQ/LBCS/boundary_conditions_v4"
AQM_LBCS_FILES="gfs_bndy_chem_<MM>.tile7.000.nc"
AQM_GEFS_DIR="/scratch2/NCEPDEV/naqfc/RRFS_CMAQ/GEFS_aerosol"
NEXUS_INPUT_DIR="/scratch1/RDARCH/rda-arl-gpu/Barry.Baker/emissions/nexus"
NEXUS_FIX_DIR="/scratch2/NCEPDEV/naqfc/RRFS_CMAQ/nexus/fix"
NEXUS_GRID_FN="grid_spec_GSD_HRRR_25km.nc"
```

and you should also turn off biogenic emissions in the `regional_workflow/ush/templates/aqm.rc`

## DEPENDENCIES:
None

## DOCUMENTATION:
If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the ufs-srweather-app repository (docs/UsersGuide/source) as supporting material.

## CONTRIBUTORS 
@drnimbusrain @zmoon

@JianpingHuang-NOAA you may want to test this before it gets merged